### PR TITLE
tomcat-jdbc数据源下内存泄露问题

### DIFF
--- a/paoding-rose-jade/src/main/java/net/paoding/rose/jade/dataaccess/DataAccessImpl.java
+++ b/paoding-rose-jade/src/main/java/net/paoding/rose/jade/dataaccess/DataAccessImpl.java
@@ -79,7 +79,7 @@ public class DataAccessImpl implements DataAccess {
 
             @Override
             public PreparedStatement createPreparedStatement(Connection con) throws SQLException {
-                PreparedStatement ps = con.prepareStatement(sql);
+                PreparedStatement ps;
                 if (returnKeys) {
                     ps = con.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
                 } else {


### PR DESCRIPTION
con.prepareStatement 在 MySQL 驱动下，会注册到 ConnectionImpl 的 openStatements 集合里面，除非显式关闭 Statement 或者 Connection，否则Connection会一直保存 Statement 的引用。

因为 DataAccessImpl.getPreparedStatementCreator 里面创建了两次 PreparedStatement，在 tomcat-jdbc 下只会关闭一次，导致每次执行SQL 语句之后 openStatements  都会引用两个 PreparedStatement，但是关闭的时候只关闭了一个，造成内存泄露。

目前只发现 tomcat-jdbc 下有该问题，因为 Spring Boot 默认使用的是 tomcat-jdbc，Rose 集成Spring Boot 之后，不注意的话，常常会出现该问题。
